### PR TITLE
don't look in assets anymore for static files

### DIFF
--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -129,7 +129,6 @@ STATIC_ROOT = os.path.join(PROJECT_ROOT, 'static')
 # where collectstatic looks for static files
 STATICFILES_DIRS = (
     os.path.join(PROJECT_ROOT, 'build'),
-    os.path.join(PROJECT_ROOT, 'assets'),
 )
 
 REST_FRAMEWORK = {


### PR DESCRIPTION
Everything's handled by webpack these days in the frontend dir, so we don't need Django to look in `/assets/` anymore